### PR TITLE
Make sure the random display name is always more than 0.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/xvfb/XvfbBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/xvfb/XvfbBuildWrapper.java
@@ -183,7 +183,10 @@ public class XvfbBuildWrapper extends BuildWrapper {
 
         if (displayName == null) {
             final Executor executor = build.getExecutor();
-            displayNameUsed = executor.getNumber();
+            displayNameUsed = executor.getNumber() + 1;
+            if(displayNameUsed>99 || displayNameUsed<=0) {
+            	displayNameUsed = 1 + (int) (Math.random() * 99);
+            }
         }
         else {
             displayNameUsed = displayName;


### PR DESCRIPTION
Hello,

I've made some small adaptations to your code for the random display name. According to the Jenkins javadoc for Executor, getNumber will start from 0, which is not wanted for Xvfb. Increasing this number with one will solve this problem. Furthermore I've added a check so the random number will remain between 1 and 100, as to conform to your documentation on the main page of the plugin.

With kind regards,

Jeroen
