### PR TITLE
Prevent NPE when NullConverter registered

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/xvfb/XvfbEnvironmentConverter.java
+++ b/src/main/java/org/jenkinsci/plugins/xvfb/XvfbEnvironmentConverter.java
@@ -16,7 +16,7 @@ public class XvfbEnvironmentConverter implements Converter {
     private static final String DISPLAY_NAME_USED_ATTR       = "displayNameUsed";
 
     public boolean canConvert(@SuppressWarnings("rawtypes") Class type) {
-        return XvfbEnvironment.class.isAssignableFrom(type);
+        return type != null && XvfbEnvironment.class.isAssignableFrom(type);
     }
 
     public void marshal(Object source, HierarchicalStreamWriter writer, MarshallingContext context) {


### PR DESCRIPTION
NullConverter tolerates type = null, http://grepcode.com/file/repo1.maven.org/maven2/com.thoughtworks.xstream/xstream/1.4.7/com/thoughtworks/xstream/converters/basic/NullConverter.java#NullConverter
As a result, com.thoughtworks.xstream.core.DefaultConverterLookup.typeToConverterMap get element with key = null and sends it to XvfbEnvironmentConverter.canConvert() when registering XvfbEnvironmentConverter
