### PR TITLE
Add support for killing stray Xvfb processes.

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/xvfb/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/xvfb/Messages.properties
@@ -34,6 +34,7 @@ XvfbBuildWrapper.Stopping = Xvfb stopping
 XvfbBuildWrapper.NoInstallationsConfigured = No Xvfb installations defined, please define one in the configuration. Once defined you\u2019ll need to choose one under Advanced options for Xvfb plugin job settings and save job configuration.
 XvfbBuildWrapper.FailedToStart = Xvfb failed to start, consult the lines above for errors
 XvfbBuildWrapper.KillingZombies = Trying to kill zombie Xvfb process that\u2019s occupying display name: {0} and frame buffer directory: {1}
+XvfbBuildWrapper.KillOldProcess = Trying to kill stray Xvfb process that\u2019s occupying display name: {0} and process ID: {1}
 XvfbBuildWrapper.ZombieSlainFailed = Unable to kill zombie Xvfb process, you\u2019ll need to do your own slaying.
 XvfbBuildWrapper.AssignedLabelString.InvalidBooleanExpression = Invalid boolean expression: {0}
 XvfbBuildWrapper.AssignedLabelString.NoMatch.DidYouMean = There\u2019s no slave/cloud that matches this assignment. Did you mean \u2018{1}\u2019 instead of \u2018{0}\u2019?

--- a/src/main/resources/org/jenkinsci/plugins/xvfb/XvfbBuildWrapper/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/xvfb/XvfbBuildWrapper/config.jelly
@@ -82,6 +82,10 @@
         <f:entry title="${%Shutdown Xvfb with whole job, not just with the main build action}" field="shutdownWithBuild">
             <f:checkbox value="${instance.shutdownWithBuild}" />
         </f:entry>
+        
+        <f:entry title="${%Kill existing Xvfb process, if found}" field="killExistingInstance">
+            <f:checkbox value="${instance.killExistingInstance}" />
+        </f:entry>
     </f:advanced>
 
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/xvfb/XvfbBuildWrapper/help-killExistingInstance.html
+++ b/src/main/resources/org/jenkinsci/plugins/xvfb/XvfbBuildWrapper/help-killExistingInstance.html
@@ -1,0 +1,32 @@
+<!--
+
+    Copyright © 2012, Zoran Regvart
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+    ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+    The views and conclusions contained in the software and documentation are those
+    of the authors and should not be interpreted as representing official policies,
+    either expressed or implied, of the FreeBSD Project.
+
+-->
+<div>Should existing Xvfb instances running on the same Display Name be killed
+    prior to starting a new instance.</div>


### PR DESCRIPTION
If a job isn't explicitly shut down, Xvfb processes can be left behind, which claim a given display port (and block new processes from start, causing all jobs to fail).

These failures can happen eg if the Jenkins master crashes, or if the network connection between master & executor drops briefly.
