### PR TITLE
increase default wait time as occasionally does not seem long enough

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/xvfb/AutoDisplayNameFilterStream.java
+++ b/src/main/java/org/jenkinsci/plugins/xvfb/AutoDisplayNameFilterStream.java
@@ -47,7 +47,7 @@ public class AutoDisplayNameFilterStream extends FilterOutputStream {
     private final long waitTime;
 
     protected AutoDisplayNameFilterStream(final OutputStream decorated) {
-        this(decorated, 10);
+        this(decorated, 30);
     }
 
     protected AutoDisplayNameFilterStream(final OutputStream decorated, final int waitTime) {


### PR DESCRIPTION
Every so often we're getting
```
FATAL: No display name received from Xvfb within 10 seconds
java.lang.IllegalStateException: No display name received from Xvfb within 10 seconds
```
This on a a dedicated aws mx4large slave, so shouldn't be that under powered, but happens a few times a week across a hundred or so jobs.
