### PR TITLE
Compatibility with jenkinsci/jenkins#6025

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/xvfb/Xvfb.java
+++ b/src/main/java/org/jenkinsci/plugins/xvfb/Xvfb.java
@@ -327,11 +327,10 @@ public class Xvfb extends SimpleBuildWrapper {
             try {
                 @SuppressWarnings("unchecked")
                 final ConcurrentHashMap<String, List<XvfbEnvironment>> oldZombies = (ConcurrentHashMap<String, List<XvfbEnvironment>>) fileOfZombies.read();
-
+                fileOfZombies.delete();
                 return oldZombies;
             } catch (final IOException ignore) {
-            } finally {
-                fileOfZombies.delete();
+                // ignore
             }
         }
 


### PR DESCRIPTION
This method is changing in jenkinsci/jenkins#6025 to throw IOException, so callers need to be adapted.